### PR TITLE
Added explanation of how KeyDown events are handled in the OS X system

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,7 +148,18 @@ Mach port where it is placed into an event queue. Events can then be read from
 this queue by threads with sufficient privileges calling the
 ``mach_ipc_dispatch`` function. This most commonly occurs through, and is
 handled by, an ``NSApplication`` main event loop, via an ``NSEvent`` of
-``NSEventType`` ``KeyDown``.
+``NSEventType`` ``KeyDown``. When a ``KeyDown NSEvent`` is sent to the app on OS X, 
+the interrupt signal triggers an interrupt event in the I/O Kit kext keyboard driver.
+The driver translates the signal into a key code which is then passed to the OS X
+WindowServer process. The WindowServer, in turn, dispatches the event to any appropriate
+applications that are active or listening, through their Mach port. The event is placed
+into an event queue, where it can be read by threads with sufficient privileges by
+calling the mach_ipc_dispatch function.
+
+To handle the KeyDown event, the NSApplication main event loop comes into play.
+It handles the event via an NSEvent of NSEventType KeyDown, ensuring that the
+appropriate actions are taken based on the specific key pressed. This process allows
+the OS X system to receive and process keyboard input from the user effectively.
 
 (On GNU/Linux) the Xorg server listens for keycodes
 ---------------------------------------------------


### PR DESCRIPTION
Explanation of how KeyDown events are handled in the OS X system. The existing paragraph describes the initial steps of the process, such as the interrupt signal triggering an interrupt event in the I/O Kit kext keyboard driver and the translation of the signal into a key code.

The added information expands on this by explaining how the key code is passed to the OS X WindowServer process. The WindowServer then dispatches the event to appropriate applications through their Mach port, where it is placed into an event queue. The events in the queue can be read by threads with sufficient privileges using the mach_ipc_dispatch function.

Additionally, this pull request emphasizes the role of the NSApplication main event loop in handling the KeyDown event. The main event loop ensures that the event is processed correctly by an NSEvent of NSEventType KeyDown. By providing this explanation, users can better understand the process by which the OS X system receives and responds to keyboard input from the user.

Please review and merge this pull request to enhance the clarity and comprehensiveness of the paragraph regarding the handling of KeyDown events on OS X.